### PR TITLE
NIGHTLY: use preconfig_conreq and run_conreq commands

### DIFF
--- a/root/etc/cont-init.d/01-config-app
+++ b/root/etc/cont-init.d/01-config-app
@@ -7,4 +7,4 @@ DEBUG="False" && export DEBUG
 
 cd "${APP_DIR}" || exit 1
 
-python3 ./manage.py preconfig_conreq $(id -u hotio) $(id -g hotio)
+python3 manage.py preconfig_conreq $(id -u hotio) $(id -g hotio)

--- a/root/etc/cont-init.d/01-config-app
+++ b/root/etc/cont-init.d/01-config-app
@@ -3,16 +3,8 @@
 
 umask "${UMASK}"
 
-DATA_DIR="${CONFIG_DIR}" && export DATA_DIR
-DEBUG="False"            && export DEBUG
+DEBUG="False" && export DEBUG
 
 cd "${APP_DIR}" || exit 1
 
-python3 ./manage.py migrate --noinput
-python3 ./manage.py collectstatic --link --noinput
-python3 ./manage.py compress
-
-chown -R hotio:hotio "${CONFIG_DIR}"
-
-# shellcheck disable=SC2086
-s6-setuidgid hotio python3 ./manage.py run_huey --quiet &
+python3 ./manage.py preconfig_conreq $(id -u hotio) $(id -g hotio)

--- a/root/etc/services.d/conreq/run
+++ b/root/etc/services.d/conreq/run
@@ -8,4 +8,6 @@ DATA_DIR="${CONFIG_DIR}" && export DATA_DIR
 cd "${APP_DIR}" || exit 1
 
 # shellcheck disable=SC2086
-exec s6-setuidgid hotio hypercorn --bind 0.0.0.0:8000 --access-logfile "${CONFIG_DIR}/logs/access.log" --websocket-ping-interval 20 --workers "$(nproc)" ${ARGS} conreq.asgi:application
+exec s6-setuidgid hotio python3 \
+     manage.py run_conreq \
+     --disable-preconfig


### PR DESCRIPTION
Conreq start commands have changed. PR utilizes the new two-step start up procedure for Linux.

With the old set of commands, Conreq may face problems on first-time setup.