### PR TITLE
RELEASE: use preconfig_conreq and run_conreq commands

### DIFF
--- a/root/etc/cont-init.d/01-config-app
+++ b/root/etc/cont-init.d/01-config-app
@@ -3,16 +3,8 @@
 
 umask "${UMASK}"
 
-DATA_DIR="${CONFIG_DIR}" && export DATA_DIR
-DEBUG="False"            && export DEBUG
+DEBUG="False" && export DEBUG
 
 cd "${APP_DIR}" || exit 1
 
-python3 ./manage.py migrate --noinput
-python3 ./manage.py collectstatic --link --noinput
-python3 ./manage.py compress
-
-chown -R hotio:hotio "${CONFIG_DIR}"
-
-# shellcheck disable=SC2086
-s6-setuidgid hotio python3 ./manage.py run_huey --quiet &
+python3 manage.py preconfig_conreq $(id -u hotio) $(id -g hotio)

--- a/root/etc/services.d/conreq/run
+++ b/root/etc/services.d/conreq/run
@@ -5,16 +5,9 @@ umask "${UMASK}"
 
 DATA_DIR="${CONFIG_DIR}" && export DATA_DIR
 
-DAPHNE_PARAMS="-b 0.0.0.0"
-if [[ "${SSL}" == true ]] && [[ -f "${SSL_CERT}" ]] && [[ -f "${SSL_KEY}" ]]; then
-    DAPHNE_PARAMS="-e ssl:8000:privateKey=${SSL_KEY}:certKey=${SSL_CERT}"
-
-elif [[ "${SSL}" == true ]]; then
-    [[ ! -f "${SSL_CERT}" ]] && echo "Not starting with SSL. Could not find the certificate \"${SSL_CERT}\"."
-    [[ ! -f "${SSL_KEY}" ]] && echo "Not starting with SSL. Could not find the key \"${SSL_KEY}\"."
-fi
-
 cd "${APP_DIR}" || exit 1
 
 # shellcheck disable=SC2086
-exec s6-setuidgid hotio daphne ${DAPHNE_PARAMS} conreq.asgi:application --access-log "${CONFIG_DIR}/logs/access.log"
+exec s6-setuidgid hotio python3 \
+     manage.py run_conreq \
+     --disable-preconfig


### PR DESCRIPTION
Conreq start commands have changed. PR utilizes the new two-step start up procedure for Linux.

With the old set of commands, Conreq may face problems on first-time setup.